### PR TITLE
Switch to .env based configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+NAS_IP=10.0.0.23
+RADARR_PORT=7878
+SONARR_PORT=8989
+RADARR_API_KEY=your_radarr_api_key
+RADARR_BASE_PATH=/api/v3
+SONARR_API_KEY=your_sonarr_api_key
+SONARR_BASE_PATH=/api/v3
+MCP_SERVER_PORT=3000
+# Optional services
+JELLYFIN_BASE_URL=http://10.0.0.23:5055
+JELLYFIN_API_KEY=your_jellyfin_api_key
+JELLYFIN_USER_ID=your_jellyfin_user_id
+PLEX_BASE_URL=http://10.0.0.23:32400
+PLEX_TOKEN=your_plex_token

--- a/README.md
+++ b/README.md
@@ -63,28 +63,18 @@ The configuration wizard will guide you through setting up:
 - Sonarr API key and port
 - MCP server port
 
-You can also manually edit the `config.json` file:
+Configuration values are stored in a `.env` file. You can create or edit this file manually.
+An example `.env` looks like:
 
-```json
-{
-  "nasConfig": {
-    "ip": "10.0.0.23",
-    "port": "7878"
-  },
-  "radarrConfig": {
-    "apiKey": "YOUR_RADARR_API_KEY",
-    "basePath": "/api/v3",
-    "port": "7878"
-  },
-  "sonarrConfig": {
-    "apiKey": "YOUR_SONARR_API_KEY",
-    "basePath": "/api/v3",
-    "port": "8989"
-  },
-  "server": {
-    "port": 3000
-  }
-}
+```bash
+NAS_IP=10.0.0.23
+RADARR_PORT=7878
+SONARR_PORT=8989
+RADARR_API_KEY=YOUR_RADARR_API_KEY
+RADARR_BASE_PATH=/api/v3
+SONARR_API_KEY=YOUR_SONARR_API_KEY
+SONARR_BASE_PATH=/api/v3
+MCP_SERVER_PORT=3000
 ```
 
 ## Available MCP Tools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ scripts = { radarr-sonarr-mcp = "radarr_sonarr_mcp.cli:main" }
 dependencies = [
   "mcp>=0.1.0",
   "requests>=2.28.0",
-  "pydantic>=2.0.0"
+  "pydantic>=2.0.0",
+  "python-dotenv>=1.0.0"
 ]
 optional-dependencies = { dev = ["pytest>=7.0.0"] }
 

--- a/radarr_sonarr_mcp/cli.py
+++ b/radarr_sonarr_mcp/cli.py
@@ -3,7 +3,15 @@
 import argparse
 import logging
 
-from .config import Config, NasConfig, RadarrConfig, SonarrConfig, ServerConfig, load_config, save_config
+from .config import (
+    Config,
+    NasConfig,
+    RadarrConfig,
+    SonarrConfig,
+    ServerConfig,
+    load_config,
+    save_env,
+)
 from .server import create_server
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -84,9 +92,9 @@ def configure():
         )
     )
     
-    # Save config
-    save_config(new_config)
-    logging.info("Configuration saved successfully!")
+    # Save config to .env file
+    save_env(new_config)
+    logging.info("Configuration saved successfully to .env")
     logging.info(f"To start the server, run: radarr-sonarr-mcp start")
     
     return new_config

--- a/radarr_sonarr_mcp/config.py
+++ b/radarr_sonarr_mcp/config.py
@@ -6,6 +6,10 @@ from dataclasses import dataclass
 from typing import Any
 import json
 import os
+from dotenv import load_dotenv
+
+# Load environment variables from a .env file if present
+load_dotenv()
 
 
 def _default_ip() -> str:
@@ -127,4 +131,20 @@ def save_config(config: Config, path: str = "config.json") -> None:
     }
     with open(path, "w") as f:
         json.dump(data, f, indent=2)
+
+
+def save_env(config: Config, path: str = ".env") -> None:
+    """Save configuration to an environment file."""
+    lines = [
+        f"NAS_IP={config.nas_config.ip}",
+        f"RADARR_PORT={config.radarr_config.port}",
+        f"SONARR_PORT={config.sonarr_config.port}",
+        f"RADARR_API_KEY={config.radarr_config.api_key}",
+        f"RADARR_BASE_PATH={config.radarr_config.base_path}",
+        f"SONARR_API_KEY={config.sonarr_config.api_key}",
+        f"SONARR_BASE_PATH={config.sonarr_config.base_path}",
+        f"MCP_SERVER_PORT={config.server_config.port}",
+    ]
+    with open(path, "w") as f:
+        f.write("\n".join(lines) + "\n")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ mcp>=0.1.0
 requests>=2.28.0
 pydantic>=2.0.0
 pytest>=7.0.0
+python-dotenv>=1.0.0

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         "fastmcp>=0.4.1",
         "requests>=2.28.0",
         "pydantic>=2.0.0",
+        "python-dotenv>=1.0.0",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
## Summary
- allow loading config from `.env`
- add helper to write `.env` files from CLI
- update CLI to generate `.env` instead of config.json
- document environment variables and add `.env.example`
- include python-dotenv dependency

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68850bfa045c8331bc76334a77f15c20